### PR TITLE
Add launcher script and UI styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+venv/
+
+# Node dependencies
+frontend/node_modules/
+
+# Build outputs
+backend/dist/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ npm install
 npm run dev
 ```
 Configure `VITE_API_URL` in `.env` if needed.
+
+## Run Everything from One Script
+
+After installing backend requirements (`pip install -r backend/requirements.txt`) and frontend dependencies (`npm --prefix frontend install`), install `pywebview` and run:
+
+```bash
+pip install pywebview
+python run_docs.py
+```
+
+This script starts the FastAPI backend and the Vite dev server, then opens a desktop window displaying the collaborative editor.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,7 +50,7 @@ export default function App() {
   }, [token])
 
   return (
-    <div style={{maxWidth: 1000, margin: '40px auto', fontFamily: 'sans-serif'}}>
+    <div className="container">
       <h1>דוקס שיתופי – MVP</h1>
 
       {!token && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,22 @@
+body {
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  background: #f5f7fa;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+input, textarea, button {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import './index.css'
 
 createRoot(document.getElementById('root')).render(<App />)

--- a/run_docs.py
+++ b/run_docs.py
@@ -1,0 +1,31 @@
+import subprocess
+import time
+import webview
+import os
+
+BACKEND_CMD = ["uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "8000"]
+FRONTEND_CMD = ["npm", "run", "dev"]
+
+
+def start_process(cmd, cwd):
+    return subprocess.Popen(cmd, cwd=cwd)
+
+
+def main():
+    backend = start_process(BACKEND_CMD, os.path.join(os.path.dirname(__file__), "backend"))
+    frontend = start_process(FRONTEND_CMD, os.path.join(os.path.dirname(__file__), "frontend"))
+    time.sleep(3)
+    try:
+        webview.create_window("Collaborative Docs", "http://localhost:5173", width=1200, height=800)
+        webview.start()
+    finally:
+        for proc in (backend, frontend):
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_docs.py` to launch backend, frontend and open webview window
- style frontend with global CSS and container class
- document single-script execution in README
- ignore build outputs and dependency folders via `.gitignore`

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfe14de09883249c6fcf9e0d68fe87